### PR TITLE
Small en-local-fix

### DIFF
--- a/Hi3Helper.Core/Lang/en.json
+++ b/Hi3Helper.Core/Lang/en.json
@@ -573,7 +573,7 @@
     "UpdateStatus4": "You're using the latest version ({0}) now!",
     "UpdateMessage4": "Returning to game launcher scope shortly...",
     "UpdateStatus5": "Version has been updated to {0}!",
-    "UpdateMessage5": "Your launcher will re-open momentarily..."
+    "UpdateMessage5": "Your launcher will re-open in a moment..."
   },
 
   "_AppNotification": {


### PR DESCRIPTION
Reason for this is that "momentarily" means for a brief amount of time, in this case we have to use "in a moment" since it means in a short amount time of something will happen. I will let you decide if you want to credit or not